### PR TITLE
Fix example

### DIFF
--- a/example/classic/default.nix
+++ b/example/classic/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> { }
 }:
 
-import ../. {
+import ../../. {
   inherit pkgs;
   configuration = ./example.nix;
 }


### PR DESCRIPTION
Fix this eval error:

  $ nix-build ./example/classic/
  error:
         … while calling the 'import' builtin

           at /home/bf/inbox/dewclaw/example/classic/default.nix:4:1:

              3|
              4| import ../. {
               | ^
              5|   inherit pkgs;

         error: opening file '/home/bf/inbox/dewclaw/example/default.nix': No such file or directory
