### PR TITLE
deploy: add --help option

### DIFF
--- a/openwrt/default.nix
+++ b/openwrt/default.nix
@@ -203,18 +203,32 @@ let
                 command scp -Op ${sshOpts} "$@"
               }
 
+              usage() {
+                echo "usage: $(basename "$0") [options]"
+                echo
+                echo "options:"
+                echo "  --help        Show this help"
+                echo "  --reload      Reload/deploy config without rebooting"
+              }
+
               main() {
                 RELOAD_ONLY=false
                 TIMEOUT=${toString rebootTimeout}s
 
                 for arg in "$@"; do
                   case "$arg" in
+                    --help)
+                      usage
+                      exit 0
+                      ;;
                     --reload)
                       RELOAD_ONLY=true
                       TIMEOUT=${toString reloadTimeout}s
                       ;;
                     *)
                       echo "error: unknown argument: $arg" >&2
+                      echo >&2
+                      usage >&2
                       exit 1
                       ;;
                   esac

--- a/openwrt/default.nix
+++ b/openwrt/default.nix
@@ -207,12 +207,18 @@ let
                 RELOAD_ONLY=false
                 TIMEOUT=${toString rebootTimeout}s
 
-                case "$@" in
-                  --reload) RELOAD_ONLY=true
-                            TIMEOUT=${toString reloadTimeout}s
-                            ;;
-                  "") ;;
-                esac
+                for arg in "$@"; do
+                  case "$arg" in
+                    --reload)
+                      RELOAD_ONLY=true
+                      TIMEOUT=${toString reloadTimeout}s
+                      ;;
+                    *)
+                      echo "error: unknown argument: $arg" >&2
+                      exit 1
+                      ;;
+                  esac
+                done
 
                 export TMP="$(umask 0077; mktemp -d)"
 


### PR DESCRIPTION
I expect CLI tools to have --help, and this is my contribution to dewclaw. Also fixes the issue that more than one argument cause the (only) valid argument to be ignored.