### PR TITLE
deploy: drop one-off use of the "service" wrapper

### DIFF
--- a/openwrt/default.nix
+++ b/openwrt/default.nix
@@ -240,7 +240,7 @@ let
                   ssh -O exit
                 else
                   ssh 'logread -l9999 -f' &
-                  ssh 'service config_generation apply_reboot 2>&1 | logger -t '"$TAG"
+                  ssh '/etc/init.d/config_generation apply_reboot 2>&1 | logger -t '"$TAG"
                   # if the previous command succeeded we're up for a reboot, at which
                   # point ssh will exit with a 255 status
                   wait %1 || true


### PR DESCRIPTION
`service <name> [args]` is a small wrapper for `/etc/init.d/<name> [args]`. dewclaw already makes several direct calls to
`/etc/init.d/config_generation`, and the one-off `service config_generation` call confused me (I had to look up the implementation in OpenWrt). I think it's better to call the script the same way everywhere.