### PR TITLE
fix: remove unused variable and fix config path

### DIFF
--- a/openwrt/uci.nix
+++ b/openwrt/uci.nix
@@ -216,7 +216,6 @@ in
           cp --no-preserve=all ${config.build.configFile} "$TMP"
           (
             umask 0077
-            C="$TMP"/${cfgName}
             S="$TMP"/secrets
             ${cfg.secretsCommand} > "$S"
             [ "$(${jq} -r type <"$S")" == "object" ] || {
@@ -237,7 +236,7 @@ in
                 ${pkgs.replace-secret}/bin/replace-secret \
                   ${lib.escapeShellArg (secretName secret)} \
                   <(${jq} -r --arg s ${arg} '.[$s]'" | tostring | sub(\"'\"; \"'\\\\'''\")" <"$S") \
-                  "$C"
+                  "$TMP"/${cfgName}
               ''
             ) (collectSecrets cfg.settings)}
           )


### PR DESCRIPTION
Eliminated an unused variable and used the correct config file path for secret replacement.

Error message from: `nix build .#router`
```
error: builder for '/nix/store/s6ynklyc56my934xh6qfhgi3w7m5xvm8-deploy-**********.drv' failed with exit code 1;
       last 7 log lines:
       >
       > In /nix/store/k1vw9g2vkgr4vpd3vi6xpjkmja338x2h-deploy-**********/bin/deploy-********** line 109:
       >   C="$TMP"/xjamc0m19h28vk1csymrd68d0m2djcjm-config
       >   ^-- SC2034 (warning): C appears unused. Verify use (or export if used externally).
       >
       > For more information:
       >   https://www.shellcheck.net/wiki/SC2034 -- C appears unused. Verify use (or ...
       For full logs, run:
         nix log /nix/store/s6ynklyc56my934xh6qfhgi3w7m5xvm8-deploy-**********.drv
error: 1 dependencies of derivation '/nix/store/ghpw1a9mkgw8yxqq35cl553bmvh3xg5s-dewclaw-env.drv' failed to build
```